### PR TITLE
Solidity-coverage dependency fix (and merges)

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -498,6 +498,12 @@ contract Finance is App, Initializable, ERC677Receiver {
             return MAX_UINT;
 
         uint256 spent = periods[currentPeriodId()].tokenStatement[_token].expenses;
+
+        // A budget decrease can cause the spent amount to be greater than period budget
+        // If so, return 0 to not allow more spending during period
+        if (spent >= settings.budgets[_token])
+            return 0;
+
         return settings.budgets[_token].sub(spent);
     }
 

--- a/apps/finance/package-lock.json
+++ b/apps/finance/package-lock.json
@@ -21,9 +21,9 @@
 			}
 		},
 		"acorn": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -46,20 +46,20 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-			"integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -141,9 +141,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -181,7 +181,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.5.0"
+				"async": "2.6.0"
 			}
 		},
 		"asynckit": {
@@ -211,7 +211,7 @@
 				"chokidar": "1.7.0",
 				"commander": "2.11.0",
 				"convert-source-map": "1.5.0",
-				"fs-readdir-recursive": "1.0.0",
+				"fs-readdir-recursive": "1.1.0",
 				"glob": "7.1.2",
 				"lodash": "4.17.4",
 				"output-file-sync": "1.1.2",
@@ -219,6 +219,26 @@
 				"slash": "1.0.0",
 				"source-map": "0.5.7",
 				"v8flags": "2.1.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
 			}
 		},
 		"babel-code-frame": {
@@ -949,7 +969,7 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bignumber.js": {
-			"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
 		},
 		"binary-extensions": {
 			"version": "1.10.0",
@@ -1191,7 +1211,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1269,9 +1289,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1373,9 +1393,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -1386,7 +1406,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -1792,7 +1813,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
@@ -1811,7 +1832,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1820,6 +1841,14 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
 			"integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
+			"requires": {
+				"webpack": "3.8.1"
+			}
+		},
+		"ethereumjs-testrpc-sc": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
+			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
 				"webpack": "3.8.1"
 			}
@@ -1850,7 +1879,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1864,15 +1893,15 @@
 				"create-hash": "1.1.3",
 				"keccakjs": "0.2.1",
 				"rlp": "2.0.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"ethereumjs-vm": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
-			"integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"async-eventemitter": "0.2.4",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-account": "2.0.4",
@@ -1881,7 +1910,7 @@
 				"fake-merkle-patricia-tree": "1.0.1",
 				"functional-red-black-tree": "1.0.1",
 				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.0",
+				"rustbn.js": "0.1.1",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -1997,6 +2026,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2081,9 +2115,9 @@
 			}
 		},
 		"fs-readdir-recursive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -2091,13 +2125,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
 				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.36"
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2231,7 +2265,6 @@
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -2270,6 +2303,11 @@
 				},
 				"delegates": {
 					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
 					"bundled": true,
 					"optional": true
 				},
@@ -2397,7 +2435,6 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2546,10 +2583,12 @@
 					"optional": true
 				},
 				"node-pre-gyp": {
-					"version": "0.6.36",
+					"version": "0.6.39",
 					"bundled": true,
 					"optional": true,
 					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
 						"mkdirp": "0.5.1",
 						"nopt": "4.0.1",
 						"npmlog": "4.1.0",
@@ -2733,7 +2772,6 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2924,11 +2962,10 @@
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
-				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
 				"inherits": "2.0.3",
 				"minimatch": "3.0.4",
@@ -3025,7 +3062,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.4",
+				"ajv": "5.3.0",
 				"har-schema": "2.0.0"
 			}
 		},
@@ -3080,7 +3117,7 @@
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
 				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"sntp": "2.1.0"
 			}
 		},
 		"hdkey": {
@@ -3089,7 +3126,7 @@
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
 				"coinstring": "2.3.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"he": {
@@ -3212,9 +3249,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -3395,27 +3432,10 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -3505,14 +3525,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3535,11 +3547,6 @@
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3578,7 +3585,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"klaw": {
@@ -4045,11 +4052,6 @@
 				"to-iso-string": "0.0.2"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4109,9 +4111,12 @@
 			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"node-abi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-			"integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+			"requires": {
+				"semver": "5.4.1"
+			}
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -4132,7 +4137,7 @@
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
 				"https-browserify": "0.0.1",
@@ -4349,7 +4354,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -4466,7 +4471,7 @@
 				"github-from-package": "0.0.0",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-abi": "2.1.1",
+				"node-abi": "2.1.2",
 				"noop-logger": "0.1.1",
 				"npmlog": "4.1.2",
 				"os-homedir": "1.0.2",
@@ -4583,7 +4588,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4593,7 +4598,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4603,6 +4608,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -4673,7 +4687,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.4.0"
+				"resolve": "1.1.7"
 			}
 		},
 		"regenerate": {
@@ -4818,12 +4832,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
 			"version": "2.0.0",
@@ -4852,6 +4863,21 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
 				"glob": "7.1.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
 			}
 		},
 		"ripemd160": {
@@ -4869,9 +4895,9 @@
 			"integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
 		},
 		"rustbn.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
-			"integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4904,9 +4930,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-			"integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
+			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
 				"bindings": "1.3.0",
 				"bip66": "1.1.5",
@@ -4982,6 +5008,21 @@
 				"glob": "7.1.2",
 				"interpret": "1.0.4",
 				"rechoir": "0.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
 			}
 		},
 		"sigmund": {
@@ -5010,9 +5051,9 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sntp": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -5184,31 +5225,6 @@
 				"sol-explore": "1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "0.18.4"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-				},
-				"ethereumjs-testrpc-sc": {
-					"version": "6.0.7",
-					"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
-					"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
-					"requires": {
-						"webpack": "3.8.1"
-					}
-				},
-				"web3": {
-					"version": "0.18.4",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
-					}
-				}
 			}
 		},
 		"solidity-parser-sc": {
@@ -5362,6 +5378,22 @@
 				"babel-register": "6.26.0",
 				"left-pad": "1.1.3",
 				"web3": "0.16.0"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+				},
+				"web3": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+						"crypto-js": "3.1.8",
+						"utf8": "2.1.2",
+						"xmlhttprequest": "1.8.0"
+					}
+				}
 			}
 		},
 		"solium": {
@@ -5375,23 +5407,18 @@
 				"lodash": "4.17.4",
 				"sol-digger": "0.0.2",
 				"sol-explore": "1.6.2",
-				"solparse": "1.3.0"
-			}
-		},
-		"solparse": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.3.0.tgz",
-			"integrity": "sha512-UlUIMg7muM/scwtSpnrjnDoATCXERw/sW+MhZsb4PcxhaOw2AUsrJR3VXZnpJHU0QN1yOJRTfNgVzwrvF/LEYA==",
-			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"solparse": "1.4.0"
 			},
 			"dependencies": {
-				"camelcase": {
+				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -5401,120 +5428,140 @@
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
 						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"ms": "2.0.0"
 					}
 				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
-				"os-locale": {
+				"growl": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+				},
+				"mocha": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.11.0",
+						"debug": "3.1.0",
+						"diff": "3.3.1",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.3",
+						"he": "1.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "4.4.0"
+					}
+				},
+				"solparse": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
+					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
 					"requires": {
-						"lcid": "1.0.0"
+						"mocha": "4.0.1",
+						"pegjs": "0.10.0",
+						"yargs": "10.0.3"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
 					}
 				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"has-flag": "2.0.0"
 					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
+						"os-locale": "2.1.0",
 						"require-directory": "2.1.1",
 						"require-main-filename": "1.0.1",
 						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"yargs-parser": "8.0.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -5690,10 +5737,31 @@
 				"through": "2.3.8"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
 				}
 			}
 		},
@@ -5705,13 +5773,13 @@
 				"chownr": "1.0.1",
 				"mkdirp": "0.5.1",
 				"pump": "1.0.2",
-				"tar-stream": "1.5.4"
+				"tar-stream": "1.5.5"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
 				"bl": "1.2.1",
 				"end-of-stream": "1.4.0",
@@ -5852,23 +5920,6 @@
 				"ethereumjs-wallet": "0.6.0",
 				"web3": "0.18.4",
 				"web3-provider-engine": "8.6.1"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-				},
-				"web3": {
-					"version": "0.18.4",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
-					}
-				}
 			}
 		},
 		"tty-browserify": {
@@ -5934,7 +5985,7 @@
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"webpack-sources": "1.0.2"
 			}
 		},
 		"unorm": {
@@ -6038,19 +6089,20 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
 		},
 		"web3": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-			"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+			"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
 				"crypto-js": "3.1.8",
 				"utf8": "2.1.2",
+				"xhr2": "0.1.4",
 				"xmlhttprequest": "1.8.0"
 			}
 		},
@@ -6059,12 +6111,12 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"clone": "2.1.1",
 				"ethereumjs-block": "1.7.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.1",
+				"ethereumjs-vm": "2.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"request": "2.83.0",
 				"semaphore": "1.1.0",
@@ -6075,6 +6127,9 @@
 				"xtend": "4.0.1"
 			},
 			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+				},
 				"ethereumjs-util": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
@@ -6087,7 +6142,18 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
+					}
+				},
+				"web3": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+						"crypto-js": "3.1.8",
+						"utf8": "2.1.2",
+						"xmlhttprequest": "1.8.0"
 					}
 				}
 			}
@@ -6097,11 +6163,11 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
 			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
 			"requires": {
-				"acorn": "5.1.2",
+				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.4",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.4",
@@ -6117,7 +6183,7 @@
 				"tapable": "0.2.8",
 				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
+				"webpack-sources": "1.0.2",
 				"yargs": "8.0.2"
 			},
 			"dependencies": {
@@ -6132,12 +6198,19 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
 				"source-list-map": "2.0.0",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"whatwg-fetch": {

--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -21,7 +21,7 @@
     "babel-register": "^6.26.0",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-testrpc": "^6.0.1",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "0.3.5",
     "solidity-sha3": "^0.4.1",
     "solium": "^0.5.5",
     "truffle": "^3.4.11",

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -156,6 +156,22 @@ contract('Finance App', accounts => {
             assert.equal(await token1.balanceOf(recipient), amount, 'recipient should have received tokens')
         })
 
+        it('can decrease budget after spending', async () => {
+            const amount = 10
+
+            // interval 0, repeat 1 (single payment)
+            await app.newPayment(token1.address, recipient, amount, time, 0, 1, '')
+
+            const newBudgetAmount = 5
+            await app.setBudget(token1.address, newBudgetAmount)
+
+            const [budget, hasBudget, remainingBudget] = await app.getBudget(token1.address)
+
+            assert.equal(budget, newBudgetAmount, 'new budget should be correct')
+            assert.isTrue(hasBudget, 'should have budget')
+            assert.equal(remainingBudget, 0, 'remaining budget should be 0')
+        })
+
         it('removing budget allows unlimited spending', async () => {
             await app.removeBudget(token2.address)
             // budget was 100

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -118,11 +118,11 @@ contract('Finance App', accounts => {
 
     it('can change period duration', async () => {
         await app.setPeriodDuration(50)
-        await app.mock_setTimestamp(160) // previous period time was 100, so in 160 must have transitioned 2
+        await app.mock_setTimestamp(160) // previous period duration was 100, so at time 160 must have transitioned 2 periods
 
         await app.tryTransitionAccountingPeriod()
 
-        assert.equal(await app.currentPeriodId(), 2, 'shpuld have transitioned 2 periods')
+        assert.equal(await app.currentPeriodId(), 2, 'should have transitioned 2 periods')
     })
 
     context('setting budget', () => {

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -120,7 +120,7 @@ contract('Finance App', accounts => {
         await app.setPeriodDuration(50)
         await app.mock_setTimestamp(160) // previous period duration was 100, so at time 160 must have transitioned 2 periods
 
-        await app.tryTransitionAccountingPeriod()
+        await app.tryTransitionAccountingPeriod(5) // transition a maximum of 5 accounting periods
 
         assert.equal(await app.currentPeriodId(), 2, 'should have transitioned 2 periods')
     })

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -116,6 +116,15 @@ contract('Finance App', accounts => {
         assert.equal(await token2.balanceOf(recipient), 190, 'recipient should have received tokens')
     })
 
+    it('can change period duration', async () => {
+        await app.setPeriodDuration(50)
+        await app.mock_setTimestamp(160) // previous period time was 100, so in 160 must have transitioned 2
+
+        await app.tryTransitionAccountingPeriod()
+
+        assert.equal(await app.currentPeriodId(), 2, 'shpuld have transitioned 2 periods')
+    })
+
     context('setting budget', () => {
         const recipient = accounts[1]
         const time = 22

--- a/apps/fundraising/contracts/Fundraising.sol
+++ b/apps/fundraising/contracts/Fundraising.sol
@@ -290,6 +290,10 @@ contract Fundraising is App, Initializable, ERC677Receiver {
 
         SalePeriod storage period = sale.periods[sale.currentPeriod];
 
+        // Make sure calculatePrice is executed running with the correct period set
+        // All entry points to this function should have performed the transition
+        assert(getTimestamp() < period.periodEnds);
+
         pricePrecision = 10 ** 8;  // given that exchangeRate is a uint, we need more precision for interpolating
         isInversePrice = sale.isInversePrice;
         price = period.initialPrice.mul(pricePrecision);

--- a/apps/fundraising/contracts/Fundraising.sol
+++ b/apps/fundraising/contracts/Fundraising.sol
@@ -134,7 +134,7 @@ contract Fundraising is App, Initializable, ERC677Receiver {
         uint256 returnTokens = _buy(_saleId, msg.sender, _payedTokens);
 
         // No need to return tokens as we never take them from sender's balance
-        assert(raisedToken.transferFrom(msg.sender, vault, _payedTokens.sub(returnTokens)));
+        require(raisedToken.transferFrom(msg.sender, vault, _payedTokens.sub(returnTokens)));
     }
 
     /**
@@ -149,9 +149,9 @@ contract Fundraising is App, Initializable, ERC677Receiver {
 
         uint256 returnTokens = _buy(saleId, _sender, _value);
 
-        assert(raisedToken.transfer(vault, _value.sub(returnTokens)));
+        require(raisedToken.transfer(vault, _value.sub(returnTokens)));
         if (returnTokens > 0)
-            assert(raisedToken.transfer(_sender, returnTokens));
+            require(raisedToken.transfer(_sender, returnTokens));
 
         return true;
     }
@@ -294,7 +294,7 @@ contract Fundraising is App, Initializable, ERC677Receiver {
         isInversePrice = sale.isInversePrice;
         price = period.initialPrice.mul(pricePrecision);
 
-        if (period.finalPrice != 0) { // interpolate price by period
+        if (period.initialPrice != period.finalPrice) { // interpolate price by period
             uint256 periodDelta = uint256(period.periodEnds).sub(uint256(sale.periodStartTime));
             uint256 periodState = getTimestamp().sub(uint256(sale.periodStartTime));
             if (period.finalPrice > period.initialPrice) {

--- a/apps/fundraising/contracts/Fundraising.sol
+++ b/apps/fundraising/contracts/Fundraising.sol
@@ -337,5 +337,7 @@ contract Fundraising is App, Initializable, ERC677Receiver {
         }
     }
 
-    function getTimestamp() internal constant returns (uint256) { return now; }
+    function getTimestamp() internal constant returns (uint256) {
+        return now;
+    }
 }

--- a/apps/fundraising/package-lock.json
+++ b/apps/fundraising/package-lock.json
@@ -21,9 +21,9 @@
 			}
 		},
 		"acorn": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -46,20 +46,20 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-			"integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -141,9 +141,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -181,7 +181,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.5.0"
+				"async": "2.6.0"
 			}
 		},
 		"asynckit": {
@@ -1169,7 +1169,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1247,9 +1247,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1351,9 +1351,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -1364,7 +1364,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -1761,7 +1762,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
@@ -1780,7 +1781,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1789,6 +1790,14 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
 			"integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
+			"requires": {
+				"webpack": "3.8.1"
+			}
+		},
+		"ethereumjs-testrpc-sc": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
+			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
 				"webpack": "3.8.1"
 			}
@@ -1819,7 +1828,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1833,15 +1842,15 @@
 				"create-hash": "1.1.3",
 				"keccakjs": "0.2.1",
 				"rlp": "2.0.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"ethereumjs-vm": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
-			"integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"async-eventemitter": "0.2.4",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-account": "2.0.4",
@@ -1850,7 +1859,7 @@
 				"fake-merkle-patricia-tree": "1.0.1",
 				"functional-red-black-tree": "1.0.1",
 				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.0",
+				"rustbn.js": "0.1.1",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -1966,6 +1975,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2055,13 +2069,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
 				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.36"
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2195,7 +2209,6 @@
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -2234,6 +2247,11 @@
 				},
 				"delegates": {
 					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
 					"bundled": true,
 					"optional": true
 				},
@@ -2361,7 +2379,6 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2510,10 +2527,12 @@
 					"optional": true
 				},
 				"node-pre-gyp": {
-					"version": "0.6.36",
+					"version": "0.6.39",
 					"bundled": true,
 					"optional": true,
 					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
 						"mkdirp": "0.5.1",
 						"nopt": "4.0.1",
 						"npmlog": "4.1.0",
@@ -2697,7 +2716,6 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2900,28 +2918,15 @@
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-			"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
+				"inflight": "1.0.6",
 				"inherits": "2.0.3",
-				"minimatch": "0.3.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
-					}
-				}
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3013,7 +3018,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.4",
+				"ajv": "5.3.0",
 				"har-schema": "2.0.0"
 			}
 		},
@@ -3068,7 +3073,7 @@
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
 				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"sntp": "2.1.0"
 			}
 		},
 		"hdkey": {
@@ -3077,7 +3082,7 @@
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
 				"coinstring": "2.3.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"he": {
@@ -3200,9 +3205,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -3383,27 +3388,10 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -3493,14 +3481,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3523,11 +3503,6 @@
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3566,7 +3541,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"klaw": {
@@ -4028,11 +4003,6 @@
 				"to-iso-string": "0.0.2"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4045,6 +4015,29 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
 					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"requires": {
+						"inherits": "2.0.3",
+						"minimatch": "0.3.0"
+					}
+				},
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"requires": {
+						"lru-cache": "2.7.3",
+						"sigmund": "1.0.1"
+					}
 				},
 				"ms": {
 					"version": "0.7.1",
@@ -4069,9 +4062,12 @@
 			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"node-abi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-			"integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+			"requires": {
+				"semver": "5.4.1"
+			}
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -4092,7 +4088,7 @@
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
 				"https-browserify": "0.0.1",
@@ -4299,7 +4295,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -4416,7 +4412,7 @@
 				"github-from-package": "0.0.0",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-abi": "2.1.1",
+				"node-abi": "2.1.2",
 				"noop-logger": "0.1.1",
 				"npmlog": "4.1.2",
 				"os-homedir": "1.0.2",
@@ -4533,7 +4529,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4543,7 +4539,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4553,6 +4549,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -4623,7 +4628,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.4.0"
+				"resolve": "1.1.7"
 			}
 		},
 		"regenerate": {
@@ -4768,12 +4773,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
 			"version": "2.0.0",
@@ -4834,9 +4836,9 @@
 			"integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
 		},
 		"rustbn.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
-			"integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4869,9 +4871,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-			"integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
+			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
 				"bindings": "1.3.0",
 				"bip66": "1.1.5",
@@ -4990,9 +4992,9 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sntp": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -5174,16 +5176,6 @@
 				"sol-explore": "1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "0.18.4"
-			},
-			"dependencies": {
-				"ethereumjs-testrpc-sc": {
-					"version": "6.0.7",
-					"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
-					"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
-					"requires": {
-						"webpack": "3.8.1"
-					}
-				}
 			}
 		},
 		"solidity-parser-sc": {
@@ -5348,23 +5340,13 @@
 				"lodash": "4.17.4",
 				"sol-digger": "0.0.2",
 				"sol-explore": "1.6.2",
-				"solparse": "1.3.0"
-			}
-		},
-		"solparse": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.3.0.tgz",
-			"integrity": "sha512-UlUIMg7muM/scwtSpnrjnDoATCXERw/sW+MhZsb4PcxhaOw2AUsrJR3VXZnpJHU0QN1yOJRTfNgVzwrvF/LEYA==",
-			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"solparse": "1.4.0"
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -5374,130 +5356,116 @@
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
 						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"ms": "2.0.0"
 					}
 				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
-				"os-locale": {
+				"growl": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+				},
+				"mocha": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.11.0",
+						"debug": "3.1.0",
+						"diff": "3.3.1",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.3",
+						"he": "1.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "4.4.0"
+					}
+				},
+				"solparse": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
+					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
 					"requires": {
-						"lcid": "1.0.0"
+						"mocha": "4.0.1",
+						"pegjs": "0.10.0",
+						"yargs": "10.0.3"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"has-flag": "2.0.0"
 					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
+						"os-locale": "2.1.0",
 						"require-directory": "2.1.1",
 						"require-main-filename": "1.0.1",
 						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"yargs-parser": "8.0.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -5709,6 +5677,14 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
 				}
 			}
 		},
@@ -5720,13 +5696,13 @@
 				"chownr": "1.0.1",
 				"mkdirp": "0.5.1",
 				"pump": "1.0.2",
-				"tar-stream": "1.5.4"
+				"tar-stream": "1.5.5"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
 				"bl": "1.2.1",
 				"end-of-stream": "1.4.0",
@@ -5932,7 +5908,7 @@
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"webpack-sources": "1.0.2"
 			}
 		},
 		"unorm": {
@@ -6023,7 +5999,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
@@ -6045,12 +6021,12 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"clone": "2.1.1",
 				"ethereumjs-block": "1.7.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.1",
+				"ethereumjs-vm": "2.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"request": "2.83.0",
 				"semaphore": "1.1.0",
@@ -6076,7 +6052,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				},
 				"web3": {
@@ -6097,11 +6073,11 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
 			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
 			"requires": {
-				"acorn": "5.1.2",
+				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.4",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.4",
@@ -6117,7 +6093,7 @@
 				"tapable": "0.2.8",
 				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
+				"webpack-sources": "1.0.2",
 				"yargs": "8.0.2"
 			},
 			"dependencies": {
@@ -6132,12 +6108,19 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
 				"source-list-map": "2.0.0",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"whatwg-fetch": {

--- a/apps/fundraising/package.json
+++ b/apps/fundraising/package.json
@@ -21,7 +21,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
     "ethereumjs-testrpc": "^6.0.1",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "0.3.5",
     "solium": "^0.5.5",
     "truffle": "^3.4.11",
     "truffle-hdwallet-provider": "0.0.3",

--- a/apps/fundraising/test/fundraising.js
+++ b/apps/fundraising/test/fundraising.js
@@ -117,6 +117,15 @@ contract('Fundraising', accounts => {
         })
     })
 
+    it('supports increasing price sales', async () => {
+        await fundraising.newSale(zeroAddress, raisedToken.address, 10000, 10000, 0, false, 1, [11], [2, 4])
+        await fundraising.mock_setTimestamp(6)
+        const [price, inverse, precision] = await fundraising.getCurrentPrice(0)
+
+        assert.equal(price, 3 * precision, 'price and precision should be correct')
+        assert.isFalse(inverse, 'price should be inverse')
+    })
+
     context('ERC677 sales', () => {
         let etherToken, buyData = {}
 
@@ -126,6 +135,12 @@ contract('Fundraising', accounts => {
 
             const saleId = 0
             buyData = fundraising.contract.buyWithToken.getData(saleId)
+        })
+
+        it('fails when calling buy with token externally', async () => {
+            return assertInvalidOpcode(async () => {
+                console.log(await fundraising.buyWithToken(0))
+            })
         })
 
         it('buys tokens correctly', async () => {

--- a/apps/group/package-lock.json
+++ b/apps/group/package-lock.json
@@ -21,9 +21,9 @@
 			}
 		},
 		"acorn": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -46,20 +46,20 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-			"integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -141,9 +141,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -181,7 +181,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.5.0"
+				"async": "2.6.0"
 			}
 		},
 		"asynckit": {
@@ -1169,7 +1169,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1247,9 +1247,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1351,9 +1351,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -1364,7 +1364,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -1770,7 +1771,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
@@ -1789,7 +1790,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1798,6 +1799,14 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
 			"integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
+			"requires": {
+				"webpack": "3.8.1"
+			}
+		},
+		"ethereumjs-testrpc-sc": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
+			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
 				"webpack": "3.8.1"
 			}
@@ -1828,7 +1837,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1842,15 +1851,15 @@
 				"create-hash": "1.1.3",
 				"keccakjs": "0.2.1",
 				"rlp": "2.0.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"ethereumjs-vm": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
-			"integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"async-eventemitter": "0.2.4",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-account": "2.0.4",
@@ -1859,7 +1868,7 @@
 				"fake-merkle-patricia-tree": "1.0.1",
 				"functional-red-black-tree": "1.0.1",
 				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.0",
+				"rustbn.js": "0.1.1",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -1975,6 +1984,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2064,13 +2078,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
 				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.36"
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2204,7 +2218,6 @@
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -2243,6 +2256,11 @@
 				},
 				"delegates": {
 					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
 					"bundled": true,
 					"optional": true
 				},
@@ -2370,7 +2388,6 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2519,10 +2536,12 @@
 					"optional": true
 				},
 				"node-pre-gyp": {
-					"version": "0.6.36",
+					"version": "0.6.39",
 					"bundled": true,
 					"optional": true,
 					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
 						"mkdirp": "0.5.1",
 						"nopt": "4.0.1",
 						"npmlog": "4.1.0",
@@ -2706,7 +2725,6 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2897,28 +2915,15 @@
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-			"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
+				"inflight": "1.0.6",
 				"inherits": "2.0.3",
-				"minimatch": "0.3.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
-					}
-				}
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3010,7 +3015,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.4",
+				"ajv": "5.3.0",
 				"har-schema": "2.0.0"
 			}
 		},
@@ -3065,7 +3070,7 @@
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
 				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"sntp": "2.1.0"
 			}
 		},
 		"hdkey": {
@@ -3074,7 +3079,7 @@
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
 				"coinstring": "2.3.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"he": {
@@ -3197,9 +3202,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -3380,27 +3385,10 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -3490,14 +3478,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3520,11 +3500,6 @@
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3563,7 +3538,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"klaw": {
@@ -4025,11 +4000,6 @@
 				"to-iso-string": "0.0.2"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4042,6 +4012,29 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
 					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"requires": {
+						"inherits": "2.0.3",
+						"minimatch": "0.3.0"
+					}
+				},
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"requires": {
+						"lru-cache": "2.7.3",
+						"sigmund": "1.0.1"
+					}
 				},
 				"ms": {
 					"version": "0.7.1",
@@ -4066,9 +4059,12 @@
 			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"node-abi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-			"integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+			"requires": {
+				"semver": "5.4.1"
+			}
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -4089,7 +4085,7 @@
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
 				"https-browserify": "0.0.1",
@@ -4296,7 +4292,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -4413,7 +4409,7 @@
 				"github-from-package": "0.0.0",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-abi": "2.1.1",
+				"node-abi": "2.1.2",
 				"noop-logger": "0.1.1",
 				"npmlog": "4.1.2",
 				"os-homedir": "1.0.2",
@@ -4530,7 +4526,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4540,7 +4536,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4550,6 +4546,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -4620,7 +4625,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.4.0"
+				"resolve": "1.1.7"
 			}
 		},
 		"regenerate": {
@@ -4765,12 +4770,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
 			"version": "2.0.0",
@@ -4831,9 +4833,9 @@
 			"integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
 		},
 		"rustbn.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
-			"integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4866,9 +4868,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-			"integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
+			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
 				"bindings": "1.3.0",
 				"bip66": "1.1.5",
@@ -4987,9 +4989,9 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sntp": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -5161,16 +5163,6 @@
 				"sol-explore": "1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "0.18.4"
-			},
-			"dependencies": {
-				"ethereumjs-testrpc-sc": {
-					"version": "6.0.7",
-					"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
-					"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
-					"requires": {
-						"webpack": "3.8.1"
-					}
-				}
 			}
 		},
 		"solidity-parser-sc": {
@@ -5325,23 +5317,18 @@
 				"lodash": "4.17.4",
 				"sol-digger": "0.0.2",
 				"sol-explore": "1.6.2",
-				"solparse": "1.3.0"
-			}
-		},
-		"solparse": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.3.0.tgz",
-			"integrity": "sha512-UlUIMg7muM/scwtSpnrjnDoATCXERw/sW+MhZsb4PcxhaOw2AUsrJR3VXZnpJHU0QN1yOJRTfNgVzwrvF/LEYA==",
-			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"solparse": "1.4.0"
 			},
 			"dependencies": {
-				"camelcase": {
+				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -5351,120 +5338,140 @@
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
 						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"ms": "2.0.0"
 					}
 				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
-				"os-locale": {
+				"growl": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+				},
+				"mocha": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.11.0",
+						"debug": "3.1.0",
+						"diff": "3.3.1",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.3",
+						"he": "1.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "4.4.0"
+					}
+				},
+				"solparse": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
+					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
 					"requires": {
-						"lcid": "1.0.0"
+						"mocha": "4.0.1",
+						"pegjs": "0.10.0",
+						"yargs": "10.0.3"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
 					}
 				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"has-flag": "2.0.0"
 					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
+						"os-locale": "2.1.0",
 						"require-directory": "2.1.1",
 						"require-main-filename": "1.0.1",
 						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"yargs-parser": "8.0.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -5657,6 +5664,14 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
 				}
 			}
 		},
@@ -5668,13 +5683,13 @@
 				"chownr": "1.0.1",
 				"mkdirp": "0.5.1",
 				"pump": "1.0.2",
-				"tar-stream": "1.5.4"
+				"tar-stream": "1.5.5"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
 				"bl": "1.2.1",
 				"end-of-stream": "1.4.0",
@@ -5880,7 +5895,7 @@
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"webpack-sources": "1.0.2"
 			}
 		},
 		"unorm": {
@@ -5971,7 +5986,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
@@ -5993,12 +6008,12 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"clone": "2.1.1",
 				"ethereumjs-block": "1.7.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.1",
+				"ethereumjs-vm": "2.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"request": "2.83.0",
 				"semaphore": "1.1.0",
@@ -6024,7 +6039,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				},
 				"web3": {
@@ -6045,11 +6060,11 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
 			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
 			"requires": {
-				"acorn": "5.1.2",
+				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.4",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.4",
@@ -6065,7 +6080,7 @@
 				"tapable": "0.2.8",
 				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
+				"webpack-sources": "1.0.2",
 				"yargs": "8.0.2"
 			},
 			"dependencies": {
@@ -6080,12 +6095,19 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
 				"source-list-map": "2.0.0",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"whatwg-fetch": {

--- a/apps/group/package.json
+++ b/apps/group/package.json
@@ -21,7 +21,7 @@
     "babel-register": "^6.26.0",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-testrpc": "^6.0.1",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "0.3.5",
     "solium": "^0.5.5",
     "truffle": "^3.4.11",
     "truffle-hdwallet-provider": "0.0.3",

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -304,7 +304,9 @@ contract TokenManager is App, Initializable, TokenController, EVMCallScriptRunne
     * @return True if the ether is accepted, false for it to throw
     */
     function proxyPayment(address _owner) payable returns (bool) {
-        revert();
+        // Even though it is tested, solidity-coverage doesnt get it because
+        // MiniMeToken is not instrumented and entire tx is reverted
+        require(msg.sender == address(token));
         _owner;
         return false;
     }

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -97,7 +97,7 @@ contract TokenManager is App, Initializable, TokenController, EVMCallScriptRunne
     * @param _amount Number of tokens wrapped
     */
     function wrap(uint256 _amount) onlyWrapper external {
-        assert(wrappedToken.transferFrom(msg.sender, address(this), _amount));
+        require(wrappedToken.transferFrom(msg.sender, address(this), _amount));
         _mint(msg.sender, _amount);
     }
 
@@ -108,7 +108,7 @@ contract TokenManager is App, Initializable, TokenController, EVMCallScriptRunne
     function unwrap(uint256 _amount) onlyWrapper external {
         require(transferrableBalance(msg.sender, now) >= _amount);
         _burn(msg.sender, _amount);
-        assert(wrappedToken.transfer(msg.sender, _amount));
+        require(wrappedToken.transfer(msg.sender, _amount));
     }
 
     /**
@@ -180,7 +180,7 @@ contract TokenManager is App, Initializable, TokenController, EVMCallScriptRunne
 
         // transferFrom always works as controller
         // onTransfer hook always allows if transfering to token controller
-        assert(token.transferFrom(_holder, address(this), nonVested));
+        require(token.transferFrom(_holder, address(this), nonVested));
 
         RevokeVesting(_holder, _vestingId);
     }
@@ -287,15 +287,15 @@ contract TokenManager is App, Initializable, TokenController, EVMCallScriptRunne
     }
 
     function _assign(address _receiver, uint256 _amount) internal {
-        assert(token.transfer(_receiver, _amount));
+        require(token.transfer(_receiver, _amount));
     }
 
     function _burn(address _holder, uint256 _amount) internal {
-        assert(token.destroyTokens(_holder, _amount));
+        token.destroyTokens(_holder, _amount);  // minime.destroyTokens() never returns false
     }
 
     function _mint(address _receiver, uint256 _amount) internal {
-        assert(token.generateTokens(_receiver, _amount));
+        token.generateTokens(_receiver, _amount); // minime.generateTokens() never returns false
     }
 
     /**

--- a/apps/token-manager/package-lock.json
+++ b/apps/token-manager/package-lock.json
@@ -21,9 +21,9 @@
 			}
 		},
 		"acorn": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -46,20 +46,20 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-			"integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -141,9 +141,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -181,7 +181,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.5.0"
+				"async": "2.6.0"
 			}
 		},
 		"asynckit": {
@@ -1169,7 +1169,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1247,9 +1247,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1351,9 +1351,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -1364,7 +1364,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -1761,7 +1762,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
@@ -1780,7 +1781,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1789,6 +1790,14 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
 			"integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
+			"requires": {
+				"webpack": "3.8.1"
+			}
+		},
+		"ethereumjs-testrpc-sc": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
+			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
 				"webpack": "3.8.1"
 			}
@@ -1819,7 +1828,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1833,15 +1842,15 @@
 				"create-hash": "1.1.3",
 				"keccakjs": "0.2.1",
 				"rlp": "2.0.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"ethereumjs-vm": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
-			"integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"async-eventemitter": "0.2.4",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-account": "2.0.4",
@@ -1850,7 +1859,7 @@
 				"fake-merkle-patricia-tree": "1.0.1",
 				"functional-red-black-tree": "1.0.1",
 				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.0",
+				"rustbn.js": "0.1.1",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -1966,6 +1975,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2055,13 +2069,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
 				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.36"
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2195,7 +2209,6 @@
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -2234,6 +2247,11 @@
 				},
 				"delegates": {
 					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
 					"bundled": true,
 					"optional": true
 				},
@@ -2361,7 +2379,6 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2510,10 +2527,12 @@
 					"optional": true
 				},
 				"node-pre-gyp": {
-					"version": "0.6.36",
+					"version": "0.6.39",
 					"bundled": true,
 					"optional": true,
 					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
 						"mkdirp": "0.5.1",
 						"nopt": "4.0.1",
 						"npmlog": "4.1.0",
@@ -2697,7 +2716,6 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2900,28 +2918,15 @@
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-			"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
+				"inflight": "1.0.6",
 				"inherits": "2.0.3",
-				"minimatch": "0.3.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
-					}
-				}
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3013,7 +3018,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.4",
+				"ajv": "5.3.0",
 				"har-schema": "2.0.0"
 			}
 		},
@@ -3068,7 +3073,7 @@
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
 				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"sntp": "2.1.0"
 			}
 		},
 		"hdkey": {
@@ -3077,7 +3082,7 @@
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
 				"coinstring": "2.3.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"he": {
@@ -3200,9 +3205,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -3383,27 +3388,10 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -3493,14 +3481,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3523,11 +3503,6 @@
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3566,7 +3541,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"klaw": {
@@ -4028,11 +4003,6 @@
 				"to-iso-string": "0.0.2"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4045,6 +4015,29 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
 					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"requires": {
+						"inherits": "2.0.3",
+						"minimatch": "0.3.0"
+					}
+				},
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"requires": {
+						"lru-cache": "2.7.3",
+						"sigmund": "1.0.1"
+					}
 				},
 				"ms": {
 					"version": "0.7.1",
@@ -4069,9 +4062,12 @@
 			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"node-abi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-			"integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+			"requires": {
+				"semver": "5.4.1"
+			}
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -4092,7 +4088,7 @@
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
 				"https-browserify": "0.0.1",
@@ -4299,7 +4295,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -4416,7 +4412,7 @@
 				"github-from-package": "0.0.0",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-abi": "2.1.1",
+				"node-abi": "2.1.2",
 				"noop-logger": "0.1.1",
 				"npmlog": "4.1.2",
 				"os-homedir": "1.0.2",
@@ -4533,7 +4529,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4543,7 +4539,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4553,6 +4549,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -4623,7 +4628,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.4.0"
+				"resolve": "1.1.7"
 			}
 		},
 		"regenerate": {
@@ -4768,12 +4773,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
 			"version": "2.0.0",
@@ -4834,9 +4836,9 @@
 			"integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
 		},
 		"rustbn.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
-			"integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4869,9 +4871,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-			"integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
+			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
 				"bindings": "1.3.0",
 				"bip66": "1.1.5",
@@ -4990,9 +4992,9 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sntp": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -5174,16 +5176,6 @@
 				"sol-explore": "1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "0.18.4"
-			},
-			"dependencies": {
-				"ethereumjs-testrpc-sc": {
-					"version": "6.0.7",
-					"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
-					"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
-					"requires": {
-						"webpack": "3.8.1"
-					}
-				}
 			}
 		},
 		"solidity-parser-sc": {
@@ -5348,23 +5340,13 @@
 				"lodash": "4.17.4",
 				"sol-digger": "0.0.2",
 				"sol-explore": "1.6.2",
-				"solparse": "1.3.0"
-			}
-		},
-		"solparse": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.3.0.tgz",
-			"integrity": "sha512-UlUIMg7muM/scwtSpnrjnDoATCXERw/sW+MhZsb4PcxhaOw2AUsrJR3VXZnpJHU0QN1yOJRTfNgVzwrvF/LEYA==",
-			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"solparse": "1.4.0"
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -5374,130 +5356,116 @@
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
 						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"ms": "2.0.0"
 					}
 				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
-				"os-locale": {
+				"growl": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+				},
+				"mocha": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.11.0",
+						"debug": "3.1.0",
+						"diff": "3.3.1",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.3",
+						"he": "1.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "4.4.0"
+					}
+				},
+				"solparse": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
+					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
 					"requires": {
-						"lcid": "1.0.0"
+						"mocha": "4.0.1",
+						"pegjs": "0.10.0",
+						"yargs": "10.0.3"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"has-flag": "2.0.0"
 					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
+						"os-locale": "2.1.0",
 						"require-directory": "2.1.1",
 						"require-main-filename": "1.0.1",
 						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"yargs-parser": "8.0.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -5709,6 +5677,14 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
 				}
 			}
 		},
@@ -5720,13 +5696,13 @@
 				"chownr": "1.0.1",
 				"mkdirp": "0.5.1",
 				"pump": "1.0.2",
-				"tar-stream": "1.5.4"
+				"tar-stream": "1.5.5"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
 				"bl": "1.2.1",
 				"end-of-stream": "1.4.0",
@@ -5932,7 +5908,7 @@
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"webpack-sources": "1.0.2"
 			}
 		},
 		"unorm": {
@@ -6023,7 +5999,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
@@ -6045,12 +6021,12 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"clone": "2.1.1",
 				"ethereumjs-block": "1.7.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.1",
+				"ethereumjs-vm": "2.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"request": "2.83.0",
 				"semaphore": "1.1.0",
@@ -6076,7 +6052,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				},
 				"web3": {
@@ -6097,11 +6073,11 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
 			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
 			"requires": {
-				"acorn": "5.1.2",
+				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.4",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.4",
@@ -6117,7 +6093,7 @@
 				"tapable": "0.2.8",
 				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
+				"webpack-sources": "1.0.2",
 				"yargs": "8.0.2"
 			},
 			"dependencies": {
@@ -6132,12 +6108,19 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
 				"source-list-map": "2.0.0",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"whatwg-fetch": {

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -20,7 +20,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
     "ethereumjs-testrpc": "^6.0.1",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "0.3.5",
     "solium": "^0.5.5",
     "truffle": "^3.4.11",
     "truffle-hdwallet-provider": "0.0.3",

--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -65,6 +65,14 @@ contract('Token Manager', accounts => {
             assert.equal(await token.balanceOf(tokenManager.address), 0, 'token manager should have 0 tokens')
         })
 
+        it('cannot assign more tokens than owned', async () => {
+            await tokenManager.issue(50)
+
+            return assertInvalidOpcode(async () => {
+                await tokenManager.assign(holder, 51)
+            })
+        })
+
         it('cannot wrap tokens', async () => {
             return assertInvalidOpcode(async () => {
                 await tokenManager.wrap(100, { from: holder })
@@ -125,7 +133,7 @@ contract('Token Manager', accounts => {
             })
 
             it('can transfer half mid vesting', async () => {
-                await timetravel(3000)
+                await timetravel(start + (vesting - start) / 2)
 
                 await token.transfer(accounts[2], 20, { from: holder })
 
@@ -252,6 +260,16 @@ contract('Token Manager', accounts => {
                 await token.transfer(tokenManager.address, 100, { from: holder100 })
                 await tokenManager.assignVested(holder100, 100, 1e11, 1e11, 1e11, false)
 
+                return assertInvalidOpcode(async () => {
+                    await tokenManager.unwrap(100, { from: holder100 })
+                })
+            })
+
+            it('fails if unwrapping more tokens than token managers balance', async () => {
+                // after being wrapped, as token controller we can move tokens at our will
+                // this scenario shouldn't happen in reality, as wrapped tokens should be
+                // trustless tokens in which this operation is not allowed
+                await wrappedToken.transferFrom(tokenManager.address, accounts[7], 100)
                 return assertInvalidOpcode(async () => {
                     await tokenManager.unwrap(100, { from: holder100 })
                 })

--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -25,6 +25,12 @@ contract('Token Manager', accounts => {
         })
     })
 
+    it('fails when sending ether to token', async () => {
+        return assertInvalidOpcode(async () => {
+            await token.send(1) // transfer 1 wei to token contract
+        })
+    })
+
     context('for native tokens', () => {
         const holder = accounts[1]
 
@@ -129,6 +135,14 @@ contract('Token Manager', accounts => {
             it('cannot transfer non-vested tokens', async () => {
                 return assertInvalidOpcode(async () => {
                     await token.transfer(accounts[2], 10, { from: holder })
+                })
+            })
+
+            it('can approve non-vested tokens but transferFrom fails', async () => {
+                await token.approve(accounts[2], 10, { from: holder })
+
+                return assertInvalidOpcode(async () => {
+                    await token.transferFrom(holder, accounts[2], 10, { from: accounts[2] })
                 })
             })
 

--- a/apps/vault/package-lock.json
+++ b/apps/vault/package-lock.json
@@ -21,9 +21,9 @@
 			}
 		},
 		"acorn": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -46,20 +46,20 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-			"integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -141,9 +141,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -181,7 +181,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.5.0"
+				"async": "2.6.0"
 			}
 		},
 		"asynckit": {
@@ -1124,9 +1124,9 @@
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"camelcase": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1169,7 +1169,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1193,13 +1193,13 @@
 			}
 		},
 		"cliui": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wrap-ansi": "2.1.0"
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
 			}
 		},
 		"clone": {
@@ -1247,9 +1247,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1330,17 +1330,6 @@
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
 				"which": "1.3.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
-					}
-				}
 			}
 		},
 		"cryptiles": {
@@ -1362,9 +1351,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -1375,7 +1364,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -1589,13 +1579,6 @@
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 			"requires": {
 				"prr": "0.0.0"
-			},
-			"dependencies": {
-				"prr": {
-					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-				}
 			}
 		},
 		"error-ex": {
@@ -1779,7 +1762,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
@@ -1798,7 +1781,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1807,6 +1790,14 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
 			"integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
+			"requires": {
+				"webpack": "3.8.1"
+			}
+		},
+		"ethereumjs-testrpc-sc": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
+			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
 				"webpack": "3.8.1"
 			}
@@ -1837,7 +1828,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1851,15 +1842,15 @@
 				"create-hash": "1.1.3",
 				"keccakjs": "0.2.1",
 				"rlp": "2.0.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"ethereumjs-vm": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
-			"integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"async-eventemitter": "0.2.4",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-account": "2.0.4",
@@ -1868,7 +1859,7 @@
 				"fake-merkle-patricia-tree": "1.0.1",
 				"functional-red-black-tree": "1.0.1",
 				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.0",
+				"rustbn.js": "0.1.1",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -1984,6 +1975,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2007,12 +2003,11 @@
 			}
 		},
 		"find-up": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"locate-path": "2.0.0"
 			}
 		},
 		"for-each": {
@@ -2074,25 +2069,23 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
 				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.36"
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+					"bundled": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -2101,19 +2094,16 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+					"bundled": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -2122,43 +2112,36 @@
 				},
 				"asn1": {
 					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+					"bundled": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+					"bundled": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+					"bundled": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+					"bundled": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+					"bundled": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -2166,24 +2149,21 @@
 				},
 				"block-stream": {
 					"version": "0.0.9",
-					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+					"bundled": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
 				},
 				"boom": {
 					"version": "2.10.1",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+					"bundled": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"bundled": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -2191,62 +2171,51 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+					"bundled": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+					"bundled": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+					"bundled": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+					"bundled": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+					"bundled": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-					"optional": true,
+					"bundled": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2254,16 +2223,14 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"debug": {
 					"version": "2.6.8",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2271,25 +2238,26 @@
 				},
 				"deep-extend": {
 					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"bundled": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+					"bundled": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2297,25 +2265,21 @@
 				},
 				"extend": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+					"bundled": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+					"bundled": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -2325,13 +2289,11 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+					"bundled": true
 				},
 				"fstream": {
 					"version": "1.0.11",
-					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+					"bundled": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -2341,8 +2303,7 @@
 				},
 				"fstream-ignore": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -2352,8 +2313,7 @@
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -2368,8 +2328,7 @@
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2377,16 +2336,14 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2398,19 +2355,16 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+					"bundled": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+					"bundled": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2419,15 +2373,12 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-					"optional": true,
+					"bundled": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2437,13 +2388,11 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+					"bundled": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2453,8 +2402,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2462,44 +2410,37 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+					"bundled": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+					"bundled": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"bundled": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"bundled": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2507,20 +2448,17 @@
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"bundled": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+					"bundled": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2528,20 +2466,17 @@
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+					"bundled": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+					"bundled": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2552,58 +2487,52 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+					"bundled": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+					"bundled": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
-					"version": "0.6.36",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-					"integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+					"version": "0.6.39",
+					"bundled": true,
 					"optional": true,
 					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
 						"mkdirp": "0.5.1",
 						"nopt": "4.0.1",
 						"npmlog": "4.1.0",
@@ -2617,8 +2546,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2627,8 +2555,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2639,45 +2566,38 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+					"bundled": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+					"bundled": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2686,36 +2606,30 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+					"bundled": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+					"bundled": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+					"bundled": true
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"bundled": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"bundled": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2726,16 +2640,14 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
 					"version": "2.2.9",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+					"bundled": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2748,8 +2660,7 @@
 				},
 				"request": {
 					"version": "2.81.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2778,48 +2689,40 @@
 				},
 				"rimraf": {
 					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"bundled": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+					"bundled": true
 				},
 				"semver": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"bundled": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-					"optional": true,
+					"bundled": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
 				},
 				"sshpk": {
 					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2835,16 +2738,14 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2853,36 +2754,31 @@
 				},
 				"string_decoder": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"bundled": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
 					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+					"bundled": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+					"bundled": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2891,8 +2787,7 @@
 				},
 				"tar-pack": {
 					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2907,8 +2802,7 @@
 				},
 				"tough-cookie": {
 					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2916,8 +2810,7 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2925,31 +2818,26 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"bundled": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+					"bundled": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+					"bundled": true
 				},
 				"uuid": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+					"bundled": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
-					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2957,8 +2845,7 @@
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2966,8 +2853,7 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true
 				}
 			}
 		},
@@ -2994,6 +2880,18 @@
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1",
 				"wide-align": "1.1.2"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
 			}
 		},
 		"get-caller-file": {
@@ -3020,23 +2918,15 @@
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-			"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
+				"inflight": "1.0.6",
 				"inherits": "2.0.3",
-				"minimatch": "0.3.0"
-			},
-			"dependencies": {
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
-					}
-				}
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3063,6 +2953,13 @@
 			"requires": {
 				"min-document": "2.19.0",
 				"process": "0.5.2"
+			},
+			"dependencies": {
+				"process": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+				}
 			}
 		},
 		"globals": {
@@ -3121,7 +3018,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.4",
+				"ajv": "5.3.0",
 				"har-schema": "2.0.0"
 			}
 		},
@@ -3142,9 +3039,9 @@
 			}
 		},
 		"has-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -3176,7 +3073,7 @@
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
 				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"sntp": "2.1.0"
 			}
 		},
 		"hdkey": {
@@ -3185,7 +3082,7 @@
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
 				"coinstring": "2.3.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"he": {
@@ -3308,9 +3205,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -3491,22 +3388,10 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -3596,14 +3481,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3626,11 +3503,6 @@
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3669,7 +3541,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"klaw": {
@@ -3792,6 +3664,13 @@
 				"prr": "1.0.1",
 				"semver": "5.4.1",
 				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"prr": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+				}
 			}
 		},
 		"levn": {
@@ -3804,15 +3683,14 @@
 			}
 		},
 		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
 				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"strip-bom": "3.0.0"
 			}
 		},
 		"loader-runner": {
@@ -3837,13 +3715,6 @@
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
-			},
-			"dependencies": {
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-				}
 			}
 		},
 		"lodash": {
@@ -3929,9 +3800,13 @@
 			}
 		},
 		"lru-cache": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
 		},
 		"ltgt": {
 			"version": "2.2.0",
@@ -4128,11 +4003,6 @@
 				"to-iso-string": "0.0.2"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4145,6 +4015,29 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
 					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"requires": {
+						"inherits": "2.0.3",
+						"minimatch": "0.3.0"
+					}
+				},
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"requires": {
+						"lru-cache": "2.7.3",
+						"sigmund": "1.0.1"
+					}
 				},
 				"ms": {
 					"version": "0.7.1",
@@ -4169,9 +4062,12 @@
 			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"node-abi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-			"integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+			"requires": {
+				"semver": "5.4.1"
+			}
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -4192,7 +4088,7 @@
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
 				"https-browserify": "0.0.1",
@@ -4212,11 +4108,6 @@
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
-				"process": {
-					"version": "0.11.10",
-					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
-				},
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -4362,11 +4253,13 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"lcid": "1.0.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -4402,7 +4295,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -4443,12 +4336,9 @@
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-exists": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"requires": {
-				"pinkie-promise": "2.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -4466,13 +4356,11 @@
 			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
 		},
 		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"pify": "2.3.0"
 			}
 		},
 		"pbkdf2": {
@@ -4524,7 +4412,7 @@
 				"github-from-package": "0.0.0",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-abi": "2.1.1",
+				"node-abi": "2.1.2",
 				"noop-logger": "0.1.1",
 				"npmlog": "4.1.2",
 				"os-homedir": "1.0.2",
@@ -4559,9 +4447,9 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
@@ -4569,9 +4457,9 @@
 			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 		},
 		"prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -4641,7 +4529,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4651,7 +4539,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4661,6 +4549,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -4683,22 +4580,22 @@
 			}
 		},
 		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 			"requires": {
-				"load-json-file": "1.1.0",
+				"load-json-file": "2.0.0",
 				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"path-type": "2.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
 			}
 		},
 		"readable-stream": {
@@ -4731,7 +4628,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.4.0"
+				"resolve": "1.1.7"
 			}
 		},
 		"regenerate": {
@@ -4876,12 +4773,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
 			"version": "2.0.0",
@@ -4942,9 +4836,9 @@
 			"integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
 		},
 		"rustbn.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
-			"integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4977,9 +4871,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-			"integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
+			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
 				"bindings": "1.3.0",
 				"bip66": "1.1.5",
@@ -5098,9 +4992,9 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sntp": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -5125,6 +5019,147 @@
 				"require-from-string": "1.2.1",
 				"semver": "5.4.1",
 				"yargs": "4.8.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "1.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				},
+				"window-size": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+				},
+				"yargs": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"lodash.assign": "4.2.0",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"window-size": "0.2.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "2.4.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"requires": {
+						"camelcase": "3.0.0",
+						"lodash.assign": "4.2.0"
+					}
+				}
 			}
 		},
 		"solidity-coverage": {
@@ -5141,16 +5176,6 @@
 				"sol-explore": "1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "0.18.4"
-			},
-			"dependencies": {
-				"ethereumjs-testrpc-sc": {
-					"version": "6.0.7",
-					"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
-					"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
-					"requires": {
-						"webpack": "3.8.1"
-					}
-				}
 			}
 		},
 		"solidity-parser-sc": {
@@ -5161,6 +5186,147 @@
 				"mocha": "2.5.3",
 				"pegjs": "0.10.0",
 				"yargs": "4.8.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "1.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				},
+				"window-size": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+				},
+				"yargs": {
+					"version": "4.8.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"lodash.assign": "4.2.0",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"window-size": "0.2.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "2.4.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"requires": {
+						"camelcase": "3.0.0",
+						"lodash.assign": "4.2.0"
+					}
+				}
 			}
 		},
 		"solium": {
@@ -5174,17 +5340,134 @@
 				"lodash": "4.17.4",
 				"sol-digger": "0.0.2",
 				"sol-explore": "1.6.2",
-				"solparse": "1.3.0"
-			}
-		},
-		"solparse": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.3.0.tgz",
-			"integrity": "sha512-UlUIMg7muM/scwtSpnrjnDoATCXERw/sW+MhZsb4PcxhaOw2AUsrJR3VXZnpJHU0QN1yOJRTfNgVzwrvF/LEYA==",
-			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"solparse": "1.4.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"growl": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+				},
+				"mocha": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.11.0",
+						"debug": "3.1.0",
+						"diff": "3.3.1",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.3",
+						"he": "1.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "4.4.0"
+					}
+				},
+				"solparse": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
+					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
+					"requires": {
+						"mocha": "4.0.1",
+						"pegjs": "0.10.0",
+						"yargs": "10.0.3"
+					}
+				},
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
 			}
 		},
 		"source-list-map": {
@@ -5265,13 +5548,32 @@
 			}
 		},
 		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
 			}
 		},
 		"string.prototype.trim": {
@@ -5306,12 +5608,9 @@
 			}
 		},
 		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"requires": {
-				"is-utf8": "0.2.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -5378,6 +5677,14 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
 				}
 			}
 		},
@@ -5389,13 +5696,13 @@
 				"chownr": "1.0.1",
 				"mkdirp": "0.5.1",
 				"pump": "1.0.2",
-				"tar-stream": "1.5.4"
+				"tar-stream": "1.5.5"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
 				"bl": "1.2.1",
 				"end-of-stream": "1.4.0",
@@ -5493,6 +5800,11 @@
 						"path-is-absolute": "1.0.1"
 					}
 				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
 				"mocha": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
@@ -5570,26 +5882,6 @@
 				"yargs": "3.10.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
-						"wordwrap": "0.0.2"
-					}
-				},
-				"window-size": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -5616,7 +5908,7 @@
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"webpack-sources": "1.0.2"
 			}
 		},
 		"unorm": {
@@ -5707,7 +5999,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
@@ -5729,12 +6021,12 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"clone": "2.1.1",
 				"ethereumjs-block": "1.7.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.1",
+				"ethereumjs-vm": "2.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"request": "2.83.0",
 				"semaphore": "1.1.0",
@@ -5760,7 +6052,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				},
 				"web3": {
@@ -5781,11 +6073,11 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
 			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
 			"requires": {
-				"acorn": "5.1.2",
+				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.4",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.4",
@@ -5801,108 +6093,10 @@
 				"tapable": "0.2.8",
 				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
+				"webpack-sources": "1.0.2",
 				"yargs": "8.0.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "2.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
-					}
-				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"requires": {
-						"pify": "2.3.0"
-					}
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -5910,49 +6104,23 @@
 					"requires": {
 						"has-flag": "2.0.0"
 					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-				},
-				"yargs": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"requires": {
-						"camelcase": "4.1.0"
-					}
 				}
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
 				"source-list-map": "2.0.0",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"whatwg-fetch": {
@@ -5969,9 +6137,9 @@
 			}
 		},
 		"which-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wide-align": {
 			"version": "1.1.2",
@@ -5979,12 +6147,24 @@
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"requires": {
 				"string-width": "1.0.2"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
 			}
 		},
 		"window-size": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -5998,6 +6178,18 @@
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -6042,33 +6234,67 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 			"requires": {
+				"camelcase": "4.1.0",
 				"cliui": "3.2.0",
 				"decamelize": "1.2.0",
 				"get-caller-file": "1.0.2",
-				"lodash.assign": "4.2.0",
-				"os-locale": "1.4.0",
-				"read-pkg-up": "1.0.1",
+				"os-locale": "2.1.0",
+				"read-pkg-up": "2.0.0",
 				"require-directory": "2.1.1",
 				"require-main-filename": "1.0.1",
 				"set-blocking": "2.0.0",
-				"string-width": "1.0.2",
-				"which-module": "1.0.0",
-				"window-size": "0.2.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
 				"y18n": "3.2.1",
-				"yargs-parser": "2.4.1"
+				"yargs-parser": "7.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				}
 			}
 		},
 		"yargs-parser": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 			"requires": {
-				"camelcase": "3.0.0",
-				"lodash.assign": "4.2.0"
+				"camelcase": "4.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
 			}
 		}
 	}

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -20,7 +20,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
     "ethereumjs-testrpc": "^6.0.1",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "0.3.5",
     "solium": "^0.5.5",
     "truffle": "^3.4.11",
     "truffle-hdwallet-provider": "0.0.3",

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -50,9 +50,9 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     /**
     * @notice Initializes Voting app (some parameters won't be modifiable after being set)
     * @param _token MiniMeToken address that will be used as governance token
-    * @param _supportRequiredPct Percentage of voters that must support a voting for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
-    * @param _minAcceptQuorumPct Percetage of total voting power that must support a voting  for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
-    * @param _voteTime Seconds that a voting will be open for token holders to vote (unless it is impossible for the fate of the vote to change)
+    * @param _supportRequiredPct Percentage of voters that must support a vote for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
+    * @param _minAcceptQuorumPct Percetage of total voting power that must support a vote for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
+    * @param _voteTime Seconds that a vote will be open for token holders to vote (unless it is impossible for the fate of the vote to change)
     */
     function initialize(
         MiniMeToken _token,
@@ -98,7 +98,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     /**
     * @notice Vote `_supports` in vote with id `_voteId`
     * @param _voteId Id for vote
-    * @param _supports Whether voter supports the voting
+    * @param _supports Whether voter supports the vote
     */
     function vote(uint256 _voteId, bool _supports) external {
         require(canVote(_voteId, msg.sender));

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -99,10 +99,11 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     * @notice Vote `_supports` in vote with id `_voteId`
     * @param _voteId Id for vote
     * @param _supports Whether voter supports the vote
+    * @param _executesIfDecided Whether it should execute the vote if it becomes decided
     */
-    function vote(uint256 _voteId, bool _supports) external {
+    function vote(uint256 _voteId, bool _supports, bool _executesIfDecided) external {
         require(canVote(_voteId, msg.sender));
-        _vote(_voteId, _supports, msg.sender);
+        _vote(_voteId, _supports, msg.sender, _executesIfDecided);
     }
 
     /**
@@ -191,10 +192,10 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
         StartVote(voteId);
 
         if (canVote(voteId, msg.sender))
-            _vote(voteId, true, msg.sender);
+            _vote(voteId, true, msg.sender, true);
     }
 
-    function _vote(uint256 _voteId, bool _supports, address _voter) internal {
+    function _vote(uint256 _voteId, bool _supports, address _voter, bool _executesIfDecided) internal {
         Vote storage vote = votes[_voteId];
 
         // this could re-enter, though we can asume the governance token is not maliciuous
@@ -216,7 +217,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
 
         CastVote(_voteId, _voter, _supports, voterStake);
 
-        if (canExecute(_voteId))
+        if (_executesIfDecided && canExecute(_voteId))
             _executeVote(_voteId);
     }
 

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -43,7 +43,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     Vote[] votes;
 
     event StartVote(uint256 indexed voteId);
-    event CastVote(uint256 indexed voteId, address indexed voter, bool supports);
+    event CastVote(uint256 indexed voteId, address indexed voter, bool supports, uint256 stake);
     event ExecuteVote(uint256 indexed voteId);
     event ChangeMinQuorum(uint256 minAcceptQuorumPct);
 
@@ -214,7 +214,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
 
         vote.voters[_voter] = _supports ? VoterState.Yea : VoterState.Nay;
 
-        CastVote(_voteId, _voter, _supports);
+        CastVote(_voteId, _voter, _supports, voterStake);
 
         if (canExecute(_voteId))
             _executeVote(_voteId);

--- a/apps/voting/package-lock.json
+++ b/apps/voting/package-lock.json
@@ -21,9 +21,9 @@
 			}
 		},
 		"acorn": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -46,20 +46,20 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-			"integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -141,9 +141,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -181,7 +181,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.5.0"
+				"async": "2.6.0"
 			}
 		},
 		"asynckit": {
@@ -211,7 +211,7 @@
 				"chokidar": "1.7.0",
 				"commander": "2.11.0",
 				"convert-source-map": "1.5.0",
-				"fs-readdir-recursive": "1.0.0",
+				"fs-readdir-recursive": "1.1.0",
 				"glob": "7.1.2",
 				"lodash": "4.17.4",
 				"output-file-sync": "1.1.2",
@@ -219,6 +219,26 @@
 				"slash": "1.0.0",
 				"source-map": "0.5.7",
 				"v8flags": "2.1.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
 			}
 		},
 		"babel-code-frame": {
@@ -949,7 +969,7 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bignumber.js": {
-			"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
 		},
 		"binary-extensions": {
 			"version": "1.10.0",
@@ -1191,7 +1211,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1269,9 +1289,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1373,9 +1393,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -1386,7 +1406,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -1783,7 +1804,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
@@ -1802,7 +1823,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1849,7 +1870,7 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
 					}
 				}
 			}
@@ -1863,15 +1884,15 @@
 				"create-hash": "1.1.3",
 				"keccakjs": "0.2.1",
 				"rlp": "2.0.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"ethereumjs-vm": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.1.tgz",
-			"integrity": "sha512-LeOtE5tXYhnQk03WSEoqxeMs67EnPXPQ7EbaQotnM2uPf1dJWEM/WSIIww/DwPPO1rRpBqfZcGSJ6IFISeQf9Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"async-eventemitter": "0.2.4",
 				"ethereum-common": "0.2.0",
 				"ethereumjs-account": "2.0.4",
@@ -1880,7 +1901,7 @@
 				"fake-merkle-patricia-tree": "1.0.1",
 				"functional-red-black-tree": "1.0.1",
 				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.0",
+				"rustbn.js": "0.1.1",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -1996,6 +2017,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
 			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2080,9 +2106,9 @@
 			}
 		},
 		"fs-readdir-recursive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -2090,13 +2116,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
 				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.36"
+				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2230,7 +2256,6 @@
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -2269,6 +2294,11 @@
 				},
 				"delegates": {
 					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
 					"bundled": true,
 					"optional": true
 				},
@@ -2396,7 +2426,6 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2545,10 +2574,12 @@
 					"optional": true
 				},
 				"node-pre-gyp": {
-					"version": "0.6.36",
+					"version": "0.6.39",
 					"bundled": true,
 					"optional": true,
 					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
 						"mkdirp": "0.5.1",
 						"nopt": "4.0.1",
 						"npmlog": "4.1.0",
@@ -2732,7 +2763,6 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2935,11 +2965,10 @@
 			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
-				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
 				"inherits": "2.0.3",
 				"minimatch": "3.0.4",
@@ -3036,7 +3065,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.4",
+				"ajv": "5.3.0",
 				"har-schema": "2.0.0"
 			}
 		},
@@ -3091,7 +3120,7 @@
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
 				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"sntp": "2.1.0"
 			}
 		},
 		"hdkey": {
@@ -3100,7 +3129,7 @@
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
 				"coinstring": "2.3.0",
-				"secp256k1": "3.3.0"
+				"secp256k1": "3.3.1"
 			}
 		},
 		"he": {
@@ -3223,9 +3252,9 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -3406,27 +3435,10 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -3516,14 +3528,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3546,11 +3550,6 @@
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3589,7 +3588,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"klaw": {
@@ -4056,11 +4055,6 @@
 				"to-iso-string": "0.0.2"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4120,9 +4114,12 @@
 			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"node-abi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-			"integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+			"requires": {
+				"semver": "5.4.1"
+			}
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -4143,7 +4140,7 @@
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
 				"https-browserify": "0.0.1",
@@ -4360,7 +4357,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -4477,7 +4474,7 @@
 				"github-from-package": "0.0.0",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-abi": "2.1.1",
+				"node-abi": "2.1.2",
 				"noop-logger": "0.1.1",
 				"npmlog": "4.1.2",
 				"os-homedir": "1.0.2",
@@ -4594,7 +4591,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4604,7 +4601,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4614,6 +4611,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -4684,7 +4690,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.4.0"
+				"resolve": "1.1.7"
 			}
 		},
 		"regenerate": {
@@ -4829,12 +4835,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
 			"version": "2.0.0",
@@ -4863,6 +4866,21 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
 				"glob": "7.1.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
 			}
 		},
 		"ripemd160": {
@@ -4880,9 +4898,9 @@
 			"integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
 		},
 		"rustbn.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.0.tgz",
-			"integrity": "sha512-AFsqeHid+1evulpDnqQuuXkh79Xl3VdUmvCRMeRxnEdEW4TDu6tBMxVTrqiT/vCsmxgrIcdrWVQW0utrGr+G6Q=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4915,9 +4933,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-			"integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
+			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
 				"bindings": "1.3.0",
 				"bip66": "1.1.5",
@@ -4993,6 +5011,21 @@
 				"glob": "7.1.2",
 				"interpret": "1.0.4",
 				"rechoir": "0.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
 			}
 		},
 		"sigmund": {
@@ -5021,9 +5054,9 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sntp": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -5205,204 +5238,12 @@
 				"sol-explore": "1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "0.18.4"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"solidity-parser-sc": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
-					"integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
-					"requires": {
-						"mocha": "2.5.3",
-						"pegjs": "0.10.0",
-						"yargs": "4.8.1"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"web3": {
-					"version": "0.18.4",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-				},
-				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
-					}
-				}
 			}
 		},
-		"solidity-sha3": {
+		"solidity-parser-sc": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
-			"integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
-			"requires": {
-				"babel-cli": "6.26.0",
-				"babel-preset-es2015": "6.24.1",
-				"babel-register": "6.26.0",
-				"left-pad": "1.1.3",
-				"web3": "0.16.0"
-			}
-		},
-		"solium": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/solium/-/solium-0.5.5.tgz",
-			"integrity": "sha1-QgrlwHCdAMGUMBWEGLuCZL2sZqo=",
-			"requires": {
-				"chokidar": "1.7.0",
-				"colors": "1.1.2",
-				"commander": "2.11.0",
-				"lodash": "4.17.4",
-				"sol-digger": "0.0.2",
-				"sol-explore": "1.6.2",
-				"solparse": "1.3.0"
-			}
-		},
-		"solparse": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.3.0.tgz",
-			"integrity": "sha512-UlUIMg7muM/scwtSpnrjnDoATCXERw/sW+MhZsb4PcxhaOw2AUsrJR3VXZnpJHU0QN1yOJRTfNgVzwrvF/LEYA==",
+			"resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
+			"integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
 			"requires": {
 				"mocha": "2.5.3",
 				"pegjs": "0.10.0",
@@ -5546,6 +5387,175 @@
 					"requires": {
 						"camelcase": "3.0.0",
 						"lodash.assign": "4.2.0"
+					}
+				}
+			}
+		},
+		"solidity-sha3": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
+			"integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
+			"requires": {
+				"babel-cli": "6.26.0",
+				"babel-preset-es2015": "6.24.1",
+				"babel-register": "6.26.0",
+				"left-pad": "1.1.3",
+				"web3": "0.16.0"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+				},
+				"web3": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+						"crypto-js": "3.1.8",
+						"utf8": "2.1.2",
+						"xmlhttprequest": "1.8.0"
+					}
+				}
+			}
+		},
+		"solium": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/solium/-/solium-0.5.5.tgz",
+			"integrity": "sha1-QgrlwHCdAMGUMBWEGLuCZL2sZqo=",
+			"requires": {
+				"chokidar": "1.7.0",
+				"colors": "1.1.2",
+				"commander": "2.11.0",
+				"lodash": "4.17.4",
+				"sol-digger": "0.0.2",
+				"sol-explore": "1.6.2",
+				"solparse": "1.4.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"growl": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+				},
+				"mocha": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.11.0",
+						"debug": "3.1.0",
+						"diff": "3.3.1",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.3",
+						"he": "1.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "4.4.0"
+					}
+				},
+				"solparse": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
+					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
+					"requires": {
+						"mocha": "4.0.1",
+						"pegjs": "0.10.0",
+						"yargs": "10.0.3"
+					}
+				},
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+					"requires": {
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -5740,10 +5750,31 @@
 				"through": "2.3.8"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+					"requires": {
+						"path-parse": "1.0.5"
+					}
 				}
 			}
 		},
@@ -5755,13 +5786,13 @@
 				"chownr": "1.0.1",
 				"mkdirp": "0.5.1",
 				"pump": "1.0.2",
-				"tar-stream": "1.5.4"
+				"tar-stream": "1.5.5"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
 				"bl": "1.2.1",
 				"end-of-stream": "1.4.0",
@@ -5902,23 +5933,6 @@
 				"ethereumjs-wallet": "0.6.0",
 				"web3": "0.18.4",
 				"web3-provider-engine": "8.6.1"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-				},
-				"web3": {
-					"version": "0.18.4",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
-					}
-				}
 			}
 		},
 		"tty-browserify": {
@@ -5984,7 +5998,7 @@
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"webpack-sources": "1.0.2"
 			}
 		},
 		"unorm": {
@@ -6088,19 +6102,20 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
 		},
 		"web3": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-			"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+			"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
 				"crypto-js": "3.1.8",
 				"utf8": "2.1.2",
+				"xhr2": "0.1.4",
 				"xmlhttprequest": "1.8.0"
 			}
 		},
@@ -6109,12 +6124,12 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"clone": "2.1.1",
 				"ethereumjs-block": "1.7.0",
 				"ethereumjs-tx": "1.3.3",
 				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.1",
+				"ethereumjs-vm": "2.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"request": "2.83.0",
 				"semaphore": "1.1.0",
@@ -6125,6 +6140,9 @@
 				"xtend": "4.0.1"
 			},
 			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+				},
 				"ethereumjs-util": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
@@ -6137,7 +6155,18 @@
 						"ethjs-util": "0.1.4",
 						"keccak": "1.3.0",
 						"rlp": "2.0.0",
-						"secp256k1": "3.3.0"
+						"secp256k1": "3.3.1"
+					}
+				},
+				"web3": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+						"crypto-js": "3.1.8",
+						"utf8": "2.1.2",
+						"xmlhttprequest": "1.8.0"
 					}
 				}
 			}
@@ -6147,11 +6176,11 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
 			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
 			"requires": {
-				"acorn": "5.1.2",
+				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.4",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.4",
@@ -6167,7 +6196,7 @@
 				"tapable": "0.2.8",
 				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
+				"webpack-sources": "1.0.2",
 				"yargs": "8.0.2"
 			},
 			"dependencies": {
@@ -6182,12 +6211,19 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
 				"source-list-map": "2.0.0",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"whatwg-fetch": {

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -20,7 +20,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
     "ethereumjs-testrpc": "^6.0.1",
-    "solidity-coverage": "^0.3.5",
+    "solidity-coverage": "0.3.5",
     "solidity-sha3": "^0.4.1",
     "solium": "^0.5.5",
     "truffle": "^3.4.11",

--- a/apps/voting/test/voting.js
+++ b/apps/voting/test/voting.js
@@ -128,7 +128,7 @@ contract('Voting App', accounts => {
                 // with new quorum at 50% it shouldn't have, but since min quorum is snapshotted
                 // it will succeed
 
-                await app.vote(voteId, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
                 await timeTravel(votingTime + 1)
 
                 const state = await app.getVote(voteId)
@@ -137,16 +137,16 @@ contract('Voting App', accounts => {
             })
 
             it('holder can vote', async () => {
-                await app.vote(voteId, false, { from: holder31 })
+                await app.vote(voteId, false, true, { from: holder31 })
                 const state = await app.getVote(voteId)
 
                 assert.equal(state[7], 31, 'nay vote should have been counted')
             })
 
             it('holder can modify vote', async () => {
-                await app.vote(voteId, true, { from: holder31 })
-                await app.vote(voteId, false, { from: holder31 })
-                await app.vote(voteId, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
+                await app.vote(voteId, false, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
                 const state = await app.getVote(voteId)
 
                 assert.equal(state[6], 31, 'yea vote should have been counted')
@@ -156,7 +156,7 @@ contract('Voting App', accounts => {
             it('token transfers dont affect voting', async () => {
                 await token.transfer(nonHolder, 31, { from: holder31 })
 
-                await app.vote(voteId, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
                 const state = await app.getVote(voteId)
 
                 assert.equal(state[6], 31, 'yea vote should have been counted')
@@ -165,49 +165,55 @@ contract('Voting App', accounts => {
 
             it('throws when non-holder votes', async () => {
                 return assertInvalidOpcode(async () => {
-                    await app.vote(voteId, true, { from: nonHolder })
+                    await app.vote(voteId, true, true, { from: nonHolder })
                 })
             })
 
             it('throws when voting after voting closes', async () => {
                 await timeTravel(votingTime + 1)
                 return assertInvalidOpcode(async () => {
-                    await app.vote(voteId, true, { from: holder31 })
+                    await app.vote(voteId, true, true, { from: holder31 })
                 })
             })
 
             it('can execute if vote is approved with support and quorum', async () => {
-                await app.vote(voteId, true, { from: holder31 })
-                await app.vote(voteId, false, { from: holder19 })
+                await app.vote(voteId, true, true, { from: holder31 })
+                await app.vote(voteId, false, true, { from: holder19 })
                 await timeTravel(votingTime + 1)
                 await app.executeVote(voteId)
                 assert.equal(await executionTarget.counter(), 2, 'should have executed result')
             })
 
             it('cannot execute vote if not enough quorum met', async () => {
-                await app.vote(voteId, true, { from: holder19 })
+                await app.vote(voteId, true, true, { from: holder19 })
                 await timeTravel(votingTime + 1)
                 return assertInvalidOpcode(async () => {
                     await app.executeVote(voteId)
                 })
             })
 
-            it('vote is executed automatically if decided', async () => {
-                await app.vote(voteId, true, { from: holder50 }) // causes execution
+            it('vote can be executed automatically if decided', async () => {
+                await app.vote(voteId, true, true, { from: holder50 }) // causes execution
+                assert.equal(await executionTarget.counter(), 2, 'should have executed result')
+            })
+
+            it('vote can be not executed automatically if decided', async () => {
+                await app.vote(voteId, true, false, { from: holder50 }) // doesnt cause execution
+                await app.executeVote(voteId)
                 assert.equal(await executionTarget.counter(), 2, 'should have executed result')
             })
 
             it('cannot re-execute vote', async () => {
-                await app.vote(voteId, true, { from: holder50 }) // causes execution
+                await app.vote(voteId, true, true, { from: holder50 }) // causes execution
                 return assertInvalidOpcode(async () => {
                     await app.executeVote(voteId)
                 })
             })
 
             it('cannot vote on executed vote', async () => {
-                await app.vote(voteId, true, { from: holder50 }) // causes execution
+                await app.vote(voteId, true, true, { from: holder50 }) // causes execution
                 return assertInvalidOpcode(async () => {
-                    await app.vote(voteId, true, { from: holder19 })
+                    await app.vote(voteId, true, true, { from: holder19 })
                 })
             })
         })
@@ -234,7 +240,7 @@ contract('Voting App', accounts => {
 
             assert.isFalse(await app.canExecute(voteId), 'vote cannot be executed')
 
-            await app.vote(voteId, true, { from: holder })
+            await app.vote(voteId, true, true, { from: holder })
 
             const [isOpen, isExecuted] = await app.getVote(voteId)
 
@@ -275,8 +281,8 @@ contract('Voting App', accounts => {
 
             assert.isFalse(await app.canExecute(voteId), 'vote cannot be executed')
 
-            await app.vote(voteId, true, { from: holder1 })
-            await app.vote(voteId, true, { from: holder2 })
+            await app.vote(voteId, true, true, { from: holder1 })
+            await app.vote(voteId, true, true, { from: holder2 })
 
             const [isOpen, isExecuted] = await app.getVote(voteId)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,15 @@
 				"readable-stream": "2.3.3"
 			}
 		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
 		"arr-diff": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -120,10 +129,40 @@
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 			"dev": true
 		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
+		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
 			"dev": true
 		},
 		"balanced-match": {
@@ -131,6 +170,25 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.8",
@@ -180,6 +238,12 @@
 				"camelcase": "2.1.1",
 				"map-obj": "1.0.1"
 			}
+		},
+		"caseless": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+			"dev": true
 		},
 		"center-align": {
 			"version": "0.1.3",
@@ -298,10 +362,25 @@
 				"wcwidth": "1.0.1"
 			}
 		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
 			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
 			"dev": true
 		},
 		"compare-func": {
@@ -568,6 +647,27 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"coveralls": {
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+			"integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+			"dev": true,
+			"requires": {
+				"js-yaml": "3.6.1",
+				"lcov-parse": "0.0.10",
+				"log-driver": "1.2.5",
+				"minimist": "1.2.0",
+				"request": "2.79.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -577,6 +677,15 @@
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
 				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1"
 			}
 		},
 		"currently-unhandled": {
@@ -595,6 +704,23 @@
 			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
 			}
 		},
 		"dateformat": {
@@ -627,6 +753,12 @@
 			"requires": {
 				"clone": "1.0.2"
 			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -667,6 +799,16 @@
 				"stream-shift": "1.0.0"
 			}
 		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
 		"end-of-stream": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
@@ -689,6 +831,12 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
 			"dev": true
 		},
 		"execa": {
@@ -767,6 +915,12 @@
 				}
 			}
 		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -825,6 +979,23 @@
 				"for-in": "1.0.2"
 			}
 		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.17"
+			}
+		},
 		"fs-extra": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
@@ -880,6 +1051,21 @@
 				}
 			}
 		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
+			"requires": {
+				"is-property": "1.0.2"
+			}
+		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -916,6 +1102,23 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
 		},
 		"git-raw-commits": {
 			"version": "1.2.0",
@@ -1128,6 +1331,54 @@
 				"uglify-js": "2.8.29"
 			}
 		},
+		"har-validator": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"commander": "2.11.0",
+				"is-my-json-valid": "2.16.1",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
 		"has-flag": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -1140,11 +1391,40 @@
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			}
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
+		},
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
 			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
 			"dev": true
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
 		},
 		"iconv-lite": {
 			"version": "0.4.19",
@@ -1315,6 +1595,18 @@
 				"is-extglob": "2.1.1"
 			}
 		},
+		"is-my-json-valid": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+			"dev": true,
+			"requires": {
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
+			}
+		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -1354,6 +1646,12 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1374,6 +1672,12 @@
 			"requires": {
 				"text-extensions": "1.7.0"
 			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -1408,10 +1712,39 @@
 				"isarray": "1.0.0"
 			}
 		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+			"integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "2.7.3"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
+			"optional": true
+		},
 		"jschardet": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
 			"integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
 		},
 		"json-stable-stringify": {
@@ -1450,6 +1783,32 @@
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -1483,6 +1842,12 @@
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
+		},
+		"lcov-parse": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
 		},
 		"lcov-result-merger": {
 			"version": "1.2.0",
@@ -1616,6 +1981,12 @@
 				"lodash._reinterpolate": "3.0.0"
 			}
 		},
+		"log-driver": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+			"dev": true
+		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -1739,6 +2110,21 @@
 				}
 			}
 		},
+		"mime-db": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.17",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.30.0"
+			}
+		},
 		"mimic-fn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -1833,6 +2219,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
 			"dev": true
 		},
 		"object-assign": {
@@ -2062,10 +2454,22 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
 		"q": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
 			"integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
 			"dev": true
 		},
 		"randomatic": {
@@ -2280,6 +2684,42 @@
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
 			"dev": true
 		},
+		"request": {
+			"version": "2.79.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.11.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "2.0.6",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.17",
+				"oauth-sign": "0.8.2",
+				"qs": "6.3.2",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.4.3",
+				"uuid": "3.1.0"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+					"dev": true
+				}
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2384,6 +2824,15 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -2441,6 +2890,36 @@
 				"through2": "2.0.3"
 			}
 		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
@@ -2482,6 +2961,12 @@
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -2644,6 +3129,15 @@
 				"extend-shallow": "2.0.1"
 			}
 		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -2655,6 +3149,19 @@
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
 			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+			"dev": true
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
+			"optional": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -2752,6 +3259,25 @@
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
 			}
 		},
 		"vinyl": {


### PR DESCRIPTION
There was an issue with different versions of multiple dependencies being mistaken in the `package-lock.json`.

Also adds a bunch of commits that have recently been merged to master.